### PR TITLE
Change from `::set-output` to output environment files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,4 +54,4 @@ export DISABLE_VERSION_CHECK=true
 output=$(/usr/bin/fp events create -v --title "$TITLE" "${additional_args[@]}" --output json)
 id=$(jq -n '$in.id' --argjson in "$output")
 
-echo "::set-output name=id::$id"
+echo "id=$id" >> $GITHUB_OUTPUT


### PR DESCRIPTION
GitHub deprecated them two days ago: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Fixes FP-2179