### PR TITLE
Update to `fp 2.0.0` and switch references to `studio.fiberplane.com`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:bullseye-slim
-ARG FP_VERSION=0.8.0
+ARG FP_VERSION=2.0.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl jq ca-certificates \

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then add the following step to a workflow of your choice:
     # ...
     steps:
       # ...
-      - uses: fiberplane/publish-event@v1
+      - uses: fiberplane/publish-event@v1.1
         with:
           # Required. Do *not* put your plaintext secret here
           api-token: ${{ secrets.FIBERPLANE_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
   fp-base-url:
     description: Base URL of the Fiberplane API
     required: true
-    default: https://fiberplane.com
+    default: https://studio.fiberplane.com
 outputs:
   id:
     description: ID of the newly created event


### PR DESCRIPTION
- Update `fp` to `v2.0.0`
- Update base url to new studio url `studio.fiberplane.com`
- Update documentation to point to new release `v1.1`